### PR TITLE
Add stream specific links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# learnathon
-Learnathon lesson plans
+# Learnathon
+
+There are effectively 5 streams:
+1. [Game](https://github.com/TechRetreat/learnathon/tree/master/game)
+2. [Web](https://github.com/TechRetreat/learnathon/tree/master/web)
+3. [Hardware](https://github.com/TechRetreat/learnathon/tree/master/hardware)
+4. Mobile
+  a. [Android](https://github.com/TechRetreat/learnathon/tree/master/mobile/android)
+  b. [iOS](https://github.com/TechRetreat/learnathon/tree/master/mobile/ios)
+  - Build a mobile geocaching application and learn the fundamentals of OOP!


### PR DESCRIPTION
I added some stream specific links. I'm thinking that this README can act as a go-to page for people in other teams to get a quick snapshot of what we're working on and what everything in #learnathon is looking like.
